### PR TITLE
Feature/max progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ just add ``WaveformSeekBar`` in your java/kotlin code or xml.
 ```
 <com.masoudss.lib.WaveformSeekBar
         app:wave_progress="33"
+        app:wave_max_progress="100"
         app:wave_width="5dp"
         app:wave_gap="2dp"
         app:wave_min_height="5dp"
@@ -55,6 +56,7 @@ just add ``WaveformSeekBar`` in your java/kotlin code or xml.
 ```
 val waveformSeekBar = WaveformSeekBar(yourContext)
 waveformSeekBar.progress = 33
+waveformSeekBar.maxProgress = 100
 waveformSeekBar.waveWidth = Utils.dp(this,5)
 waveformSeekBar.waveGap = Utils.dp(this,2)
 waveformSeekBar.waveMinHeight = Utils.dp(this,5)
@@ -70,6 +72,7 @@ waveformSeekBar.setSampleFrom(AUDIO_FILE || AUDIO_PATH)
 ```
 WaveformSeekBar waveformSeekBar = new WaveformSeekBar(yourContext);
 waveformSeekBar.setProgress(33);
+waveformSeekBar.setMaxProgress(100);
 waveformSeekBar.setWaveWidth(Utils.dp(this,5));
 waveformSeekBar.setWaveGap(Utils.dp(this,2));
 waveformSeekBar.setWaveMinHeight(Utils.dp(this,5));

--- a/app/src/main/java/com/masoudss/activity/MainActivity.kt
+++ b/app/src/main/java/com/masoudss/activity/MainActivity.kt
@@ -90,6 +90,17 @@ class MainActivity : AppCompatActivity() {
             override fun onStopTrackingTouch(seekBar: SeekBar?) {}
         })
 
+        waveMaxProgress.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener{
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                waveProgress.max = progress
+                waveformSeekBar.maxProgress = progress.toFloat()
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) {}
+
+            override fun onStopTrackingTouch(seekBar: SeekBar?) {}
+        })
+
         gravityRadioGroup.setOnCheckedChangeListener { _, checkedId ->
 
             val radioButton = gravityRadioGroup.findViewById(checkedId) as RadioButton

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -66,6 +66,7 @@
 
             <com.masoudss.lib.WaveformSeekBar
                     app:wave_progress="33"
+                    app:wave_max_progress="100"
                     app:wave_width="5dp"
                     app:wave_gap="2dp"
                     app:wave_min_height="5dp"
@@ -88,6 +89,7 @@
                     android:text="Wave Width"
                     android:layout_gravity="center"/>
             <SeekBar
+                    android:min="1"
                     android:max="100"
                     android:progress="50"
                     android:id="@+id/waveWidth"
@@ -138,6 +140,20 @@
                     android:layout_width="300dp"
                     android:layout_height="wrap_content"/>
 
+            <TextView
+                android:layout_marginTop="16dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Maximum Progress"
+                android:layout_gravity="center"/>
+            <SeekBar
+                android:min="1"
+                android:max="200"
+                android:progress="100"
+                android:id="@+id/waveMaxProgress"
+                android:layout_gravity="center"
+                android:layout_width="300dp"
+                android:layout_height="wrap_content"/>
 
             <LinearLayout
                     android:layout_marginTop="16dp"

--- a/lib/src/main/java/com/masoudss/lib/WaveformSeekBar.kt
+++ b/lib/src/main/java/com/masoudss/lib/WaveformSeekBar.kt
@@ -50,6 +50,7 @@ class WaveformSeekBar : View {
         waveBackgroundColor = ta.getColor(R.styleable.WaveformSeekBar_wave_background_color,waveBackgroundColor)
         waveProgressColor = ta.getColor(R.styleable.WaveformSeekBar_wave_progress_color,waveProgressColor)
         progress = ta.getInteger(R.styleable.WaveformSeekBar_wave_progress,progress)
+        maxProgress = ta.getFloat(R.styleable.WaveformSeekBar_wave_max_progress,maxProgress)
         val gravity = ta.getString(R.styleable.WaveformSeekBar_wave_gravity)
         waveGravity = when(gravity){
             "1" -> WaveGravity.TOP
@@ -95,7 +96,7 @@ class WaveformSeekBar : View {
             mWaveRect.set(lastWaveRight, top, lastWaveRight+waveWidth, top + waveHeight)
 
             when {
-                mWaveRect.contains(getAvailableWith()*progress/100F, mWaveRect.centerY()) -> {
+                mWaveRect.contains(getAvailableWith()*progress/maxProgress, mWaveRect.centerY()) -> {
                     var bitHeight = mWaveRect.height().toInt()
                     if (bitHeight <= 0)
                         bitHeight = waveWidth.toInt()
@@ -103,7 +104,7 @@ class WaveformSeekBar : View {
                     val bitmap = Bitmap.createBitmap(getAvailableWith(),bitHeight , Bitmap.Config.ARGB_8888)
                     mProgressCanvas.setBitmap(bitmap)
 
-                    val fillWidth = (getAvailableWith()*progress/100F)
+                    val fillWidth = (getAvailableWith()*progress/maxProgress)
 
                     mWavePaint.color = waveProgressColor
                     mProgressCanvas.drawRect(0F,0F,fillWidth,mWaveRect.bottom,mWavePaint)
@@ -114,7 +115,7 @@ class WaveformSeekBar : View {
                     val shader = BitmapShader(bitmap, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
                     mWavePaint.shader = shader
                 }
-                mWaveRect.right <= getAvailableWith()*progress/100F -> {
+                mWaveRect.right <= getAvailableWith()*progress/maxProgress -> {
                     mWavePaint.color = waveProgressColor
                     mWavePaint.shader = null
                 }
@@ -181,7 +182,7 @@ class WaveformSeekBar : View {
 
     private fun updateProgress(event: MotionEvent?){
 
-        progress = (100*event!!.x/getAvailableWith()).toInt()
+        progress = (maxProgress*event!!.x/getAvailableWith()).toInt()
         invalidate()
 
         if (onProgressChanged != null)
@@ -211,6 +212,12 @@ class WaveformSeekBar : View {
 
             if (onProgressChanged != null)
                 onProgressChanged!!.onProgressChanged(this,progress,false)
+        }
+
+    var maxProgress : Float = 100F
+        set(value) {
+            field = value
+            invalidate()
         }
 
     var waveBackgroundColor : Int = Color.LTGRAY

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -3,6 +3,7 @@
 
     <declare-styleable name="WaveformSeekBar">
         <attr name="wave_progress" format="integer"/>
+        <attr name="wave_max_progress" format="float"/>
         <attr name="wave_width" format="dimension"/>
         <attr name="wave_gap" format="dimension"/>
         <attr name="wave_min_height" format="dimension"/>


### PR DESCRIPTION
In #8 it was requested, that the max setting of the progress should be configurable. Otherwise a smooth scrolling for larger clips is not possible.
The provided changes adds a new Property `maxProgress ` which allows to configure exactly this.
The example application was also adapted and contains now an additional seekbar for the maxProgress value between 1 and 200.